### PR TITLE
Fixes to work with libstatgrab-0.90

### DIFF
--- a/src/bwm-ng.c
+++ b/src/bwm-ng.c
@@ -192,7 +192,13 @@ int main (int argc, char *argv[]) {
         deinit(1,"invalid output selected\n");
     if (input_method<0)
         deinit(1,"invalid input selected\n");
-    
+        
+#ifdef LIBSTATGRAB
+	if (sg_init(0) != 0) {
+		deinit(1,"libstatgrab failed to initialise\n");
+	}
+#endif
+
     /* init total stats to zero */
 	memset(&if_stats_total,0,(size_t)sizeof(t_iface_stats));
 #ifdef HAVE_CURSES

--- a/src/input/libstatgrab.c
+++ b/src/input/libstatgrab.c
@@ -27,7 +27,8 @@
 /* do the actual work, get and print stats if verbose */
 void get_iface_stats_libstat (char verbose) {
     sg_network_io_stats *network_stats=NULL;
-    int num_network_stats,current_if_num=0,hidden_if=0;
+    size_t num_network_stats;
+    int current_if_num=0,hidden_if=0;
 	
 	t_iface_speed_stats stats; /* local struct, used to calc total values */
     t_iface_speed_stats tmp_if_stats;
@@ -61,7 +62,8 @@ void get_iface_stats_libstat (char verbose) {
 
 void get_iface_stats_libstatdisk (char verbose) {
    sg_disk_io_stats *disk_stats=NULL;
-   int num_disk_stats,current_if_num=0,hidden_if=0;
+   size_t num_disk_stats;
+   int current_if_num=0,hidden_if=0;
 
    t_iface_speed_stats stats; /* local struct, used to calc total values */
    t_iface_speed_stats tmp_if_stats;


### PR DESCRIPTION
Fedora Project is blocked by bwm-ng not being compatible with libstatgrab-0.90/0.91. Please consider these simple changes to bring this package up to libstatgrab-0.90 compatibility.

https://bugzilla.redhat.com/show_bug.cgi?id=1119266