### PR TITLE
Use `static inline` instead of `inline`

### DIFF
--- a/src/bwm-ng.c
+++ b/src/bwm-ng.c
@@ -26,7 +26,7 @@
 
 /* handle interrupt signal */
 void sigint(int sig) FUNCATTR_NORETURN;
-inline void init(void);
+static inline void init(void);
 
 /* clear stuff and exit */
 #ifdef __STDC__
@@ -98,7 +98,7 @@ void sigint(int sig) {
 	deinit(0, NULL);
 }
 
-inline void init(void) {
+static inline void init(void) {
 	if_count=0;
 	delay=500;
 #if EXTENDED_STATS	

--- a/src/help.c
+++ b/src/help.c
@@ -24,9 +24,9 @@
 #include "global_vars.h"
 #include "help.h"
 
-inline void print_help_line(const char *short_c,const char * long_c,const char *descr);
+static inline void print_help_line(const char *short_c,const char * long_c,const char *descr);
 
-inline void print_help_line(const char *short_c,const char * long_c,const char *descr) {
+static inline void print_help_line(const char *short_c,const char * long_c,const char *descr) {
 #ifdef LONG_OPTIONS
     printf("  %-23s",long_c);
 #else

--- a/src/options.c
+++ b/src/options.c
@@ -30,12 +30,12 @@ static char* getToken(char** str, const char* delims);
 char *trim_whitespace(char *str);
 int read_config(const char *config_file);
 #endif
-inline int str2output_unit(char *optarg);
+static inline int str2output_unit(char *optarg);
 #if EXTENDED_STATS
-inline int str2output_type(char *optarg);
+static inline int str2output_type(char *optarg);
 #endif
-inline int str2out_method(char *optarg);
-inline int str2in_method(char *optarg);
+static inline int str2out_method(char *optarg);
+static inline int str2in_method(char *optarg);
 
 #ifdef CONFIG_FILE
  /******************************************************************************
@@ -65,7 +65,7 @@ static char* getToken(char** str, const char* delims) {
 /******************************************************************************/
 #endif
 
-inline int str2output_unit(char *optarg) {
+static inline int str2output_unit(char *optarg) {
     if (optarg) {
         if (!strcasecmp(optarg,"bytes")) return BYTES_OUT;
         if (!strcasecmp(optarg,"bits")) return BITS_OUT;
@@ -76,7 +76,7 @@ inline int str2output_unit(char *optarg) {
 }
 
 #if EXTENDED_STATS
-inline int str2output_type(char *optarg) {
+static inline int str2output_type(char *optarg) {
     if (optarg) {
         if (!strcasecmp(optarg,"rate")) return RATE_OUT;
         if (!strcasecmp(optarg,"max")) return MAX_OUT;
@@ -87,7 +87,7 @@ inline int str2output_type(char *optarg) {
 }
 #endif  
 
-inline int str2out_method(char *optarg) {
+static inline int str2out_method(char *optarg) {
     if (optarg) {
         if (!strcasecmp(optarg,"plain")) return PLAIN_OUT;
 #ifdef HAVE_CURSES
@@ -109,7 +109,7 @@ inline int str2out_method(char *optarg) {
 }
 
 
-inline int str2in_method(char *optarg) {
+static inline int str2in_method(char *optarg) {
     if (optarg) {
 #ifdef PROC_NET_DEV
         if (!strcasecmp(optarg,"proc")) return PROC_IN;

--- a/src/output.c
+++ b/src/output.c
@@ -25,13 +25,13 @@
 #include "output.h"
 
 inline static const char *output_type2str(void);
-inline const char *input2str(void);
-inline const char *show_all_if2str(void);
-inline ullong direction2value(char mode,struct inout_long stats);
+static inline const char *input2str(void);
+static inline const char *show_all_if2str(void);
+static inline ullong direction2value(char mode,struct inout_long stats);
 #if EXTENDED_STATS
-inline double direction_max2value(char mode,struct inouttotal_double stats,int items);
+static inline double direction_max2value(char mode,struct inouttotal_double stats,int items);
 #endif
-inline char *dyn_byte_value2str(double value,char *str,int buf_size);
+static inline char *dyn_byte_value2str(double value,char *str,int buf_size);
 char *values2str(char mode,t_iface_speed_stats stats,t_iface_stats full_stats,float multiplier,char *str,int buf_size);
 
 inline static const char *output_type2str(void) {
@@ -59,7 +59,7 @@ inline static const char *output_type2str(void) {
 }
 
 
-inline const char *input2str(void) {
+static inline const char *input2str(void) {
     switch (input_method) {
 #ifdef SYSCTL
         case SYSCTL_IN:
@@ -121,7 +121,7 @@ inline const char *input2str(void) {
     return "";
 }
 
-inline const char *show_all_if2str(void) {
+static inline const char *show_all_if2str(void) {
     switch (show_all_if) {
         case 1:
 				return " (all)";
@@ -262,7 +262,7 @@ int print_header(int option) {
 }
 
 
-inline ullong direction2value(char mode,struct inout_long stats) {
+static inline ullong direction2value(char mode,struct inout_long stats) {
     switch (mode) {
         case 0:
             return stats.in;
@@ -275,7 +275,7 @@ inline ullong direction2value(char mode,struct inout_long stats) {
 }
 
 #if EXTENDED_STATS
-inline double direction_max2value(char mode,struct inouttotal_double stats,int items) {
+static inline double direction_max2value(char mode,struct inouttotal_double stats,int items) {
     switch (mode) {
         case 0:
             return (double)(stats.in/items);
@@ -288,7 +288,7 @@ inline double direction_max2value(char mode,struct inouttotal_double stats,int i
 }
 #endif
 
-inline char *dyn_byte_value2str(double value,char *str,int buf_size) {
+static inline char *dyn_byte_value2str(double value,char *str,int buf_size) {
     if (dynamic) {
         if (value<1024)
             snprintf(str,buf_size,"%15.2f  ",value);
@@ -306,7 +306,7 @@ inline char *dyn_byte_value2str(double value,char *str,int buf_size) {
     return str;
 }
 
-inline char *dyn_bit_value2str(double value,char *str,int buf_size) {
+static inline char *dyn_bit_value2str(double value,char *str,int buf_size) {
     if (dynamic) {
         if (value<1000)
             snprintf(str,buf_size,"%15.2f  ",value);

--- a/src/process.c
+++ b/src/process.c
@@ -26,19 +26,19 @@
 
 short show_iface(char *instr, char *searchstr,char iface_is_up);
 #if HAVE_GETTIMEOFDAY
-inline long tvdiff(struct timeval newer, struct timeval older);
+static inline long tvdiff(struct timeval newer, struct timeval older);
 float get_time_delay(int iface_num);
 #endif
-inline ullong calc_new_values(ullong new, ullong old);
+static inline ullong calc_new_values(ullong new, ullong old);
 t_iface_speed_stats convert2calced_values(t_iface_speed_stats new, t_iface_speed_stats old);
 t_iface_speed_stats convert2calced_disk_values(t_iface_speed_stats new, t_iface_speed_stats old);
 #if EXTENDED_STATS
-inline void sub_avg_values(struct inouttotal_double *values,struct inouttotal_double data);
-inline void add_avg_values(struct inouttotal_double *values,struct inouttotal_double data);
-inline void save_avg_values(struct inouttotal_double *values,struct inouttotal_double *data,struct inout_long calced_stats,float multiplier);
+static inline void sub_avg_values(struct inouttotal_double *values,struct inouttotal_double data);
+static inline void add_avg_values(struct inouttotal_double *values,struct inouttotal_double data);
+static inline void save_avg_values(struct inouttotal_double *values,struct inouttotal_double *data,struct inout_long calced_stats,float multiplier);
 void save_avg(struct t_avg *avg,struct iface_speed_stats calced_stats,float multiplier);
-inline void save_sum(struct inout_long *stats,struct inout_long new_stats_values);
-inline void save_max(struct inouttotal_double *stats,struct inout_long calced_stats,float multiplier);
+static inline void save_sum(struct inout_long *stats,struct inout_long new_stats_values);
+static inline void save_max(struct inouttotal_double *stats,struct inout_long calced_stats,float multiplier);
 #endif
 
 /* returns the whether to show the iface or not
@@ -74,7 +74,7 @@ short show_iface(char *instr, char *searchstr,char iface_is_up) {
 
 #if HAVE_GETTIMEOFDAY
 /* Returns: the time difference in milliseconds. */
-inline long tvdiff(struct timeval newer, struct timeval older) {
+static inline long tvdiff(struct timeval newer, struct timeval older) {
   return labs((newer.tv_sec-older.tv_sec)*1000+
     (newer.tv_usec-older.tv_usec)/1000);
 }
@@ -95,7 +95,7 @@ float get_time_delay(int iface_num) {
 #endif
 
 /* basically new-old, but handles "overflow" of source aswell */
-inline ullong calc_new_values(ullong new, ullong old) {
+static inline ullong calc_new_values(ullong new, ullong old) {
     /* FIXME: WRAP_AROUND _might_ be wrong for libstatgrab, where the type is always long long */
     return (new>=old) ? (ullong)(new-old) : (ullong)((
 #ifdef HAVE_LIBKSTAT
@@ -136,13 +136,13 @@ t_iface_speed_stats convert2calced_disk_values(t_iface_speed_stats new, t_iface_
 
 #if EXTENDED_STATS
 /* sub old values from cached for avg stats */
-inline void sub_avg_values(struct inouttotal_double *values,struct inouttotal_double data) {
+static inline void sub_avg_values(struct inouttotal_double *values,struct inouttotal_double data) {
     values->in-=data.in;
     values->out-=data.out;
     values->total-=data.total;
 }
 
-inline void add_avg_values(struct inouttotal_double *values,struct inouttotal_double data) {
+static inline void add_avg_values(struct inouttotal_double *values,struct inouttotal_double data) {
     values->in+=data.in;
     values->out+=data.out;
     values->total+=data.total;
@@ -151,7 +151,7 @@ inline void add_avg_values(struct inouttotal_double *values,struct inouttotal_do
 
 /* put new-old bytes in inout_long struct into a inouttotal_double struct 
  * and add values to cached .value struct */
-inline void save_avg_values(struct inouttotal_double *values,struct inouttotal_double *data,struct inout_long calced_stats,float multiplier) {
+static inline void save_avg_values(struct inouttotal_double *values,struct inouttotal_double *data,struct inout_long calced_stats,float multiplier) {
     data->in=calced_stats.in*multiplier;
     data->out=calced_stats.out*multiplier;
     data->total=(calced_stats.in+calced_stats.out)*multiplier;
@@ -201,13 +201,13 @@ void save_avg(struct t_avg *avg,struct iface_speed_stats calced_stats,float mult
 }
 
 /* add current in and out bytes to totals struct */
-inline void save_sum(struct inout_long *stats,struct inout_long new_stats_values) {
+static inline void save_sum(struct inout_long *stats,struct inout_long new_stats_values) {
     stats->in+=new_stats_values.in;
     stats->out+=new_stats_values.out;
 }
 
 /* lookup old max values and save new if higher */
-inline void save_max(struct inouttotal_double *stats,struct inout_long calced_stats,float multiplier) {
+static inline void save_max(struct inouttotal_double *stats,struct inout_long calced_stats,float multiplier) {
     if (multiplier*calced_stats.in > stats->in)
         stats->in=multiplier*calced_stats.in;
     if (multiplier*calced_stats.out>stats->out)


### PR DESCRIPTION
`inline` by itself is not portably guaranteed to emit
an external definition when needed in C99. The current
code base implicitly relies on GNU89 inline semantics,
which _always_ emit an external definition. More recent
versions of GCC and Clang switch to C99/C11 inline semantics
by default, which fails with undefined references.

See also:
* http://www.greenend.org.uk/rjk/tech/inline.html
* https://clang.llvm.org/compatibility.html#inline
* http://blahg.josefsipek.net/?p=529