### PR TITLE
Add the started time in "sum" mode

### DIFF
--- a/src/bwm-ng.c
+++ b/src/bwm-ng.c
@@ -175,7 +175,8 @@ static inline void init(void) {
 #if IOSERVICE_IN
 	long_darwin_disk_names = 0;
 #endif
-
+	time_t t = time(NULL);
+	strftime(start_time, sizeof(start_time), "%c", localtime(&t));
 }
 
 /* do the main thing */

--- a/src/defines.h
+++ b/src/defines.h
@@ -31,6 +31,7 @@
 #include <limits.h>
 #include <signal.h>
 #include <string.h>
+#include <time.h>
 
 #include "../config.h"
 

--- a/src/global_vars.h
+++ b/src/global_vars.h
@@ -94,3 +94,5 @@ EXTERN t_iface_stats *if_stats;
 EXTERN t_iface_stats if_stats_total;
 
 #endif
+
+EXTERN char start_time[30];

--- a/src/output.c
+++ b/src/output.c
@@ -233,7 +233,7 @@ int print_header(int option) {
 			}
 	        fprintf(tmp_out_file,"<div class=\"bwm-ng-header\">bwm-ng bwm-ng v" VERSION " (refresh %is); input: ",html_refresh);
             fprintf(tmp_out_file,"%s", input2str());
-            fprintf(tmp_out_file,"%s", show_all_if2str());
+            fprintf(tmp_out_file,"%s", show_all_if2str()); // TODO: started
 	        fprintf(tmp_out_file,"</div><table class=\"bwm-ng-output\">");
 			fprintf(tmp_out_file,"<tr class=\"bwm-ng-head\"><td class=\"bwm-ng-name\">Interface</td><td>Rx</td><td>Tx</td><td>Total</td></tr>");
 			break;
@@ -241,10 +241,13 @@ int print_header(int option) {
 		case PLAIN_OUT_ONCE:
 		case PLAIN_OUT:
 			if (output_method==PLAIN_OUT && ansi_output) printf("\033[1;2H");
-	        printf("bwm-ng v" VERSION " (delay %2.3fs); ",(float)delay/1000);
-			if (output_method==PLAIN_OUT) printf("press 'ctrl-c' to end this%s",(ansi_output ? "\033[2;2H" : "")); else printf("input: ");
-            printf("%s", input2str());
-            printf("%s\n",show_all_if2str());
+
+	        printf("bwm-ng v" VERSION " (delay %2.3fs); ", (float)delay/1000);
+			if (output_method==PLAIN_OUT && output_type==SUM_OUT) printf("started: %s; ", start_time);
+            if (output_method==PLAIN_OUT) printf(ansi_output ? "\033[2;2H" : "\n");
+            printf("input: %s", input2str());
+            if (output_method==PLAIN_OUT) printf("; press 'ctrl-c' to end this");
+            printf("%s\n", show_all_if2str());
 			if (output_method==PLAIN_OUT) {
 				if (ansi_output)
 					printf("\033[3;2H");

--- a/src/output.c
+++ b/src/output.c
@@ -233,7 +233,8 @@ int print_header(int option) {
 			}
 	        fprintf(tmp_out_file,"<div class=\"bwm-ng-header\">bwm-ng bwm-ng v" VERSION " (refresh %is); input: ",html_refresh);
             fprintf(tmp_out_file,"%s", input2str());
-            fprintf(tmp_out_file,"%s", show_all_if2str()); // TODO: started
+            fprintf(tmp_out_file,"%s", show_all_if2str());
+            if (output_type==SUM_OUT) fprintf(tmp_out_file,"<br>Started: %s", start_time);
 	        fprintf(tmp_out_file,"</div><table class=\"bwm-ng-output\">");
 			fprintf(tmp_out_file,"<tr class=\"bwm-ng-head\"><td class=\"bwm-ng-name\">Interface</td><td>Rx</td><td>Tx</td><td>Total</td></tr>");
 			break;
@@ -245,9 +246,8 @@ int print_header(int option) {
 	        printf("bwm-ng v" VERSION " (delay %2.3fs); ", (float)delay/1000);
 			if (output_method==PLAIN_OUT && output_type==SUM_OUT) printf("started: %s; ", start_time);
             if (output_method==PLAIN_OUT) printf(ansi_output ? "\033[2;2H" : "\n");
-            printf("input: %s", input2str());
-            if (output_method==PLAIN_OUT) printf("; press 'ctrl-c' to end this");
-            printf("%s\n", show_all_if2str());
+            printf("input: %s%s", input2str(), show_all_if2str());
+            if (output_method==PLAIN_OUT) printf("; press 'ctrl-c' to end this\n");
 			if (output_method==PLAIN_OUT) {
 				if (ansi_output)
 					printf("\033[3;2H");


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7802808/38899477-a6b6bf84-42a0-11e8-9731-d1e8a35955e0.png)
The `sum` mode is useless for long periods without the time interval.
I was planned to measure month's consumption and it's better know which day the service was started