### PR TITLE
AC_QEF_C_NORETURN: Include <stdlib.h> for exit

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -148,7 +148,7 @@ AC_DEFUN([AC_QEF_C_NORETURN],
 AC_MSG_CHECKING(whether the C compiler (${CC-cc}) accepts noreturn attribute)
 AC_CACHE_VAL(qef_cv_c_noreturn,
 [qef_cv_c_noreturn=no
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <stdio.h>
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <stdlib.h>
 void f (void) __attribute__ ((noreturn));
 void f (void)
 {


### PR DESCRIPTION
The exit function is declared in <stdlib.h>, not <stdio.h>.  Without
this change, the autoconf check will always fail with strict C99
compilers which do not support implicit function declarations.