### PR TITLE
Fix potential write to unallocated memory.

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -336,7 +336,7 @@ void get_cmdln_options(int argc, char *argv[]) {
         if (pwd_entry!=NULL) {
             str=(char*)malloc(strlen(pwd_entry->pw_dir)+14);
             if(!str) {
-              printf("Fatal: failed to allocate %zu bytes.\n", strlen(pwd_entry->pw_dir)+14);
+              printf("Fatal: failed to allocate %zu bytes reading user directory for config file.\n", strlen(pwd_entry->pw_dir)+14);
               exit(EXIT_FAILURE);
             }
             snprintf(str,strlen(pwd_entry->pw_dir)+14,"%s/.bwm-ng.conf",pwd_entry->pw_dir);
@@ -496,4 +496,3 @@ void get_cmdln_options(int argc, char *argv[]) {
 		output_unit=BYTES_OUT;
     return;
 }
-

--- a/src/options.c
+++ b/src/options.c
@@ -335,6 +335,10 @@ void get_cmdln_options(int argc, char *argv[]) {
         pwd_entry=getpwuid(getuid());
         if (pwd_entry!=NULL) {
             str=(char*)malloc(strlen(pwd_entry->pw_dir)+14);
+            if(!str) {
+              printf("Fatal: failed to allocate %zu bytes.\n", strlen(pwd_entry->pw_dir)+14);
+              exit(EXIT_FAILURE);
+            }
             snprintf(str,strlen(pwd_entry->pw_dir)+14,"%s/.bwm-ng.conf",pwd_entry->pw_dir);
             read_config(str);
             free(str);


### PR DESCRIPTION
As reported in https://github.com/vgropp/bwm-ng/issues/26, exit with error in case malloc() returns with NULL, instead of considering malloc() will always work.